### PR TITLE
fix: catch credential errors, null datastores, vm-name lookup; add env-var auth for non-macOS

### DIFF
--- a/src/vsphere_mcp_server/credentials.py
+++ b/src/vsphere_mcp_server/credentials.py
@@ -1,9 +1,15 @@
 """Credential management for vSphere MCP server."""
 
 import json
+import os
+import platform
 import subprocess
 import time
 from typing import Tuple
+
+
+class CredentialError(RuntimeError):
+    """Raised when credentials cannot be retrieved or managed."""
 
 
 def extract_domain(hostname: str) -> str:
@@ -15,7 +21,21 @@ def extract_domain(hostname: str) -> str:
 
 
 def get_credentials(hostname: str) -> Tuple[str, str]:
-    """Get credentials for vSphere host with GUI prompts if needed."""
+    """Get credentials for vSphere host.
+
+    Resolution order:
+    1. VSPHERE_USERNAME / VSPHERE_PASSWORD environment variables (all platforms)
+    2. macOS Keychain cache (macOS only)
+    3. macOS GUI prompt (macOS only)
+    """
+    # Env-var override works on any platform (required for WSL / Linux)
+    env_user = os.environ.get("VSPHERE_USERNAME")
+    env_pass = os.environ.get("VSPHERE_PASSWORD")
+    if env_user and env_pass:
+        return env_user, env_pass
+
+    _ensure_supported_platform()
+
     domain = extract_domain(hostname)
     service_name = "vsphere-mcp"
 
@@ -44,7 +64,12 @@ def get_credentials(hostname: str) -> Tuple[str, str]:
 
         return stored_data["username"], stored_data["password"]
 
-    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError):
+    except (
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+        KeyError,
+        FileNotFoundError,
+    ):
         return _prompt_for_credentials(hostname, domain, service_name)
 
 
@@ -77,8 +102,12 @@ display dialog "Enter username for vSphere host {hostname}" ¬
         else:
             raise ValueError("Failed to parse username from dialog")
 
+    except FileNotFoundError as exc:
+        raise CredentialError(
+            "macOS osascript is required for GUI authentication"
+        ) from exc
     except (subprocess.CalledProcessError, IndexError, ValueError) as exc:
-        raise RuntimeError("Username input cancelled or failed") from exc
+        raise CredentialError("Username input cancelled or failed") from exc
 
     # Password prompt
     display_username = (
@@ -109,8 +138,12 @@ display dialog "Enter password for {display_username}" ¬
         else:
             raise ValueError("Failed to parse password from dialog")
 
+    except FileNotFoundError as exc:
+        raise CredentialError(
+            "macOS osascript is required for GUI authentication"
+        ) from exc
     except (subprocess.CalledProcessError, IndexError, ValueError) as exc:
-        raise RuntimeError("Password input cancelled or failed") from exc
+        raise CredentialError("Password input cancelled or failed") from exc
 
     # Normalize username format
     if "@" not in username and "\\" not in username:
@@ -141,7 +174,7 @@ display dialog "Enter password for {display_username}" ¬
             ],
             check=True,
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         pass  # Continue even if keychain storage fails
 
     return username, password
@@ -149,6 +182,7 @@ display dialog "Enter password for {display_username}" ¬
 
 def clear_credentials(hostname: str) -> bool:
     """Clear stored credentials for domain."""
+    _ensure_supported_platform()
     domain = extract_domain(hostname)
     service_name = "vsphere-mcp"
 
@@ -159,5 +193,15 @@ def clear_credentials(hostname: str) -> bool:
             capture_output=True,
         )
         return True
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return False
+
+
+def _ensure_supported_platform() -> None:
+    """Validate that the current platform supports the keychain/GUI credential flow."""
+    if platform.system() != "Darwin":
+        raise CredentialError(
+            "Credential prompts require macOS Keychain and osascript; "
+            "set VSPHERE_USERNAME and VSPHERE_PASSWORD environment variables "
+            "to use this server on non-macOS platforms (Linux, WSL, containers)"
+        )

--- a/src/vsphere_mcp_server/server.py
+++ b/src/vsphere_mcp_server/server.py
@@ -17,6 +17,8 @@ def _handle_error(e: Exception, operation: str) -> str:
     error_msg = str(e)
 
     if "Authentication failed" in error_msg:
+        if "VSPHERE_USERNAME" in error_msg:
+            return f"Authentication failed for {operation}. {error_msg}"
         return (
             f"Authentication failed for {operation}. "
             "Try clearing credentials with vsphere_clear_credentials."
@@ -84,8 +86,8 @@ def get_vm_details(hostname: str, vm_id: str) -> str:
     """
     client = VSphereClient(hostname)
     try:
-        # If vm_id doesn't start with 'vm-', assume it's a name and look up the ID
-        if not vm_id.startswith("vm-"):
+        requested_vm = vm_id
+        if not _looks_like_vm_moid(vm_id):
             vms_response = client.get("vcenter/vm")
             vms = vms_response.get("value", [])
 
@@ -101,7 +103,21 @@ def get_vm_details(hostname: str, vm_id: str) -> str:
 
             vm_id = vm_id_found
 
-        response = client.get(f"vcenter/vm/{vm_id}")
+        try:
+            response = client.get(f"vcenter/vm/{vm_id}")
+        except ConnectionError as e:
+            # Name looked like a MOID (vm-NNN) but 404'd — retry as a name lookup
+            if _looks_like_vm_moid(vm_id) and requested_vm == vm_id and "404" in str(e):
+                vms_response = client.get("vcenter/vm")
+                for vm in vms_response.get("value", []):
+                    if vm.get("name", "").lower() == requested_vm.lower():
+                        vm_id = vm.get("vm", vm_id)
+                        response = client.get(f"vcenter/vm/{vm_id}")
+                        break
+                else:
+                    raise
+            else:
+                raise
         vm = response.get("value", {})
 
         if not vm:
@@ -305,8 +321,13 @@ def list_datastores(hostname: str) -> str:
 
         result = f"Found {len(datastores)} datastores:\n\n"
         for ds in datastores:
-            capacity = ds.get("capacity", 0)
-            free_space = ds.get("free_space", 0)
+            capacity = ds.get("capacity") or 0
+            free_space = ds.get("free_space") or 0
+            if not isinstance(capacity, (int, float)) or not isinstance(
+                free_space, (int, float)
+            ):
+                capacity = 0
+                free_space = 0
             used_space = capacity - free_space
             used_pct = (used_space / capacity * 100) if capacity > 0 else 0
 
@@ -614,6 +635,11 @@ def list_vlans(hostname: str) -> str:
         return _handle_error(e, "extracting VLAN information")
     finally:
         client.close()
+
+
+def _looks_like_vm_moid(value: str) -> bool:
+    """Return True when the value looks like a vSphere VM managed object ID (e.g. vm-42)."""
+    return bool(re.fullmatch(r"vm-\d+", value))
 
 
 def main() -> None:

--- a/src/vsphere_mcp_server/vsphere_client.py
+++ b/src/vsphere_mcp_server/vsphere_client.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import requests
 import urllib3
 
-from .credentials import get_credentials
+from .credentials import CredentialError, get_credentials
 
 
 class VSphereClient:
@@ -24,7 +24,10 @@ class VSphereClient:
 
     def authenticate(self) -> None:
         """Authenticate and get session token."""
-        username, password = get_credentials(self.hostname)
+        try:
+            username, password = get_credentials(self.hostname)
+        except CredentialError as e:
+            raise ConnectionError(f"Authentication failed: {str(e)}") from e
 
         # Create basic auth header
         credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
@@ -39,7 +42,7 @@ class VSphereClient:
             self.session_token = response.json()["value"]
             self.session.headers.update({"vmware-api-session-id": self.session_token})
 
-        except requests.exceptions.RequestException as e:
+        except (requests.exceptions.RequestException, ValueError, KeyError) as e:
             raise ConnectionError(f"Authentication failed: {str(e)}") from e
 
     def get(self, endpoint: str) -> Dict[str, Any]:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from vsphere_mcp_server.credentials import extract_domain
+from vsphere_mcp_server.credentials import (
+    CredentialError,
+    extract_domain,
+    get_credentials,
+)
 
 
 def test_extract_domain():
@@ -13,3 +17,40 @@ def test_extract_domain():
         extract_domain("simple.hostname") == "simple.hostname"
     )  # Only 2 parts, returns full hostname
     assert extract_domain("single") == "single"  # Single part, returns as-is
+
+
+def test_get_credentials_from_env_vars(monkeypatch):
+    monkeypatch.setenv("VSPHERE_USERNAME", "admin@vsphere.local")
+    monkeypatch.setenv("VSPHERE_PASSWORD", "secret")
+
+    assert get_credentials("vcenter.company.local") == ("admin@vsphere.local", "secret")
+
+
+def test_get_credentials_rejects_non_macos_without_env_vars(monkeypatch):
+    monkeypatch.delenv("VSPHERE_USERNAME", raising=False)
+    monkeypatch.delenv("VSPHERE_PASSWORD", raising=False)
+    monkeypatch.setattr(
+        "vsphere_mcp_server.credentials.platform.system", lambda: "Linux"
+    )
+
+    with pytest.raises(CredentialError, match="VSPHERE_USERNAME"):
+        get_credentials("vcenter.company.local")
+
+
+def test_get_credentials_falls_back_when_security_missing(monkeypatch):
+    monkeypatch.delenv("VSPHERE_USERNAME", raising=False)
+    monkeypatch.delenv("VSPHERE_PASSWORD", raising=False)
+    monkeypatch.setattr(
+        "vsphere_mcp_server.credentials.platform.system", lambda: "Darwin"
+    )
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("security")
+
+    monkeypatch.setattr("vsphere_mcp_server.credentials.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "vsphere_mcp_server.credentials._prompt_for_credentials",
+        lambda hostname, domain, service_name: ("user@company.local", "secret"),
+    )
+
+    assert get_credentials("vcenter.company.local") == ("user@company.local", "secret")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,72 @@
+"""Regression tests for server helpers and tool edge cases."""
+
+from vsphere_mcp_server import server
+
+
+class FakeClient:
+    """Minimal fake client for server tool tests."""
+
+    responses: dict = {}
+
+    def __init__(self, hostname):
+        self.hostname = hostname
+
+    def get(self, endpoint):
+        response = self.responses[endpoint]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def post(self, endpoint, data=None):
+        response = self.responses[endpoint]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def close(self):
+        return None
+
+
+def test_looks_like_vm_moid():
+    assert server._looks_like_vm_moid("vm-42") is True
+    assert server._looks_like_vm_moid("vm-1") is True
+    assert server._looks_like_vm_moid("vm-prod-app01") is False
+    assert server._looks_like_vm_moid("my-vm") is False
+    assert server._looks_like_vm_moid("vm-") is False
+
+
+def test_get_vm_details_resolves_name_that_starts_with_vm_prefix(monkeypatch):
+    monkeypatch.setattr(server, "VSphereClient", FakeClient)
+    FakeClient.responses = {
+        "vcenter/vm": {"value": [{"name": "vm-prod-app01", "vm": "vm-42"}]},
+        "vcenter/vm/vm-42": {
+            "value": {"name": "vm-prod-app01", "power_state": "POWERED_ON"}
+        },
+    }
+
+    result = server.get_vm_details("vc.local", "vm-prod-app01")
+
+    assert "ID: vm-42" in result
+    assert "VM Details: vm-prod-app01" in result
+
+
+def test_list_datastores_handles_null_capacity(monkeypatch):
+    monkeypatch.setattr(server, "VSphereClient", FakeClient)
+    FakeClient.responses = {
+        "vcenter/datastore": {
+            "value": [
+                {
+                    "name": "ds-1",
+                    "datastore": "datastore-1",
+                    "type": "VMFS",
+                    "capacity": None,
+                    "free_space": None,
+                }
+            ]
+        }
+    }
+
+    result = server.list_datastores("vc.local")
+
+    assert "ds-1" in result
+    assert "Capacity: 0.0 GB" in result


### PR DESCRIPTION
## Summary

Three crash-level bugs fixed, plus environment variable credential support for Linux/WSL/containers.

**Bug fixes**

- **Uncaught credential exceptions** (`credentials.py`, `vsphere_client.py`) — `get_credentials()` could raise `FileNotFoundError` (when the `security` binary is missing) or `RuntimeError` (on a cancelled GUI prompt), neither of which were caught by `authenticate()` or any tool handler, causing hard crashes. Introduced `CredentialError`, normalized all credential-layer failures into it, and catch it in `authenticate()`.

- **`list_datastores()` `TypeError` on null capacity** (`server.py`) — vSphere returns `null` for `capacity` and `free_space` on inaccessible or partially populated datastores. Arithmetic on these values raised `TypeError`. Added `or 0` guards and a type check, consistent with how `get_datastore_details()` already handles this case.

- **`get_vm_details()` fails for VM names starting with `vm-`** (`server.py`) — The code used `str.startswith("vm-")` to detect MOIDs, so any VM named e.g. `vm-prod-app01` was sent directly to `GET /vcenter/vm/vm-prod-app01`, which 404s. Replaced with a `_looks_like_vm_moid()` regex (`vm-\d+`) and added a 404 fallback that retries as a name lookup.

**Feature: env-var credentials for non-macOS platforms**

The server previously failed silently (or deep into a tool call) on Linux, WSL, and containers because it depends on macOS Keychain (`security`) and GUI prompts (`osascript`). Added `VSPHERE_USERNAME` / `VSPHERE_PASSWORD` environment variable support that bypasses the macOS-specific flow entirely. The platform check now fires early with a clear, actionable error message if env vars are not set and the platform is not macOS.

```bash
export VSPHERE_USERNAME="administrator@vsphere.local"
export VSPHERE_PASSWORD="yourpassword"
```

## Test plan

- Added `tests/test_server.py` covering `_looks_like_vm_moid()`, the `vm-`-prefix name resolution fix, and the null-capacity datastore fix
- Extended `tests/test_credentials.py` with env-var resolution, non-macOS rejection, and `security`-missing fallback cases
- Test count: 1 → 7, all passing
- `black`, `isort`, and `mypy` clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)